### PR TITLE
Add aws cli as Pre-Requisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This includes:
 
 1. [Install Pulumi](https://www.pulumi.com/docs/reference/install).
 1. [Install `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).
+1. [Install AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) 
 
 ## Installing
 

--- a/python/README.md
+++ b/python/README.md
@@ -18,6 +18,7 @@ This includes:
 
 1. [Install Pulumi](https://www.pulumi.com/docs/reference/install).
 1. [Install `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).
+1. [Install AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) 
 
 ## Installing
 


### PR DESCRIPTION
AWS CLI is required to in order to deploy k8s resources to the EKS cluster.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

As `aws` command needs to be on path to create EKS cluster this should be mentioned as Pre-Requisite

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
